### PR TITLE
feat: add team management modal

### DIFF
--- a/atomic/organisms/modals/.exports.ts
+++ b/atomic/organisms/modals/.exports.ts
@@ -1,3 +1,4 @@
 export * from './AccountProfileModal.tsx';
 export * from './SimulatorLibraryModal.tsx';
 export * from './WorkspaceSettingsModal.tsx';
+export * from './TeamManagementModal.tsx';

--- a/atomic/organisms/modals/TeamManagementModal.tsx
+++ b/atomic/organisms/modals/TeamManagementModal.tsx
@@ -1,0 +1,199 @@
+import {
+  JSX,
+  WorkspaceManager,
+  IntentTypes,
+  useState,
+} from '../../.deps.ts';
+import {
+  Modal,
+  Input,
+  Select,
+  Action,
+  ActionStyleTypes,
+} from '../../.exports.ts';
+
+export type TeamManagementModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function TeamManagementModal({
+  workspaceMgr,
+  onClose,
+}: TeamManagementModalProps): JSX.Element {
+  const {
+    currentWorkspace,
+    teamMembers,
+    inviteMember,
+    removeMember,
+    updateMemberRole,
+  } = workspaceMgr.UseWorkspaceSettings();
+
+  const [selected, setSelected] = useState<string[]>([]);
+  const [bulkRole, setBulkRole] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<'Owner' | 'Editor' | 'Viewer'>('Viewer');
+
+  const toggleSelected = (email: string) => {
+    setSelected((prev) =>
+      prev.includes(email)
+        ? prev.filter((e) => e !== email)
+        : [...prev, email]
+    );
+  };
+
+  const handleBulkChange = (nextRole: string) => {
+    setBulkRole('');
+    if (!nextRole) return;
+    selected.forEach((email) =>
+      updateMemberRole(email, nextRole as 'Owner' | 'Editor' | 'Viewer')
+    );
+    setSelected([]);
+  };
+
+  const friendlyDate = (joined?: string) => {
+    if (!joined) return 'N/A';
+    try {
+      return new Date(joined).toLocaleDateString();
+    } catch {
+      return joined;
+    }
+  };
+
+  return (
+    <Modal
+      title={`Teams: ${currentWorkspace.Details.Name} Members`}
+      onClose={onClose}
+    >
+      <div class="space-y-6">
+        <div class="flex items-center justify-between">
+          <div class="text-sm text-neutral-300 font-medium">
+            Current Members
+          </div>
+          <Select
+            value={bulkRole}
+            onChange={(e: JSX.TargetedEvent<HTMLSelectElement, Event>) =>
+              handleBulkChange((e.target as HTMLSelectElement).value)
+            }
+          >
+            <option value="">Bulk change role...</option>
+            <option value="Owner">Owner</option>
+            <option value="Editor">Editor</option>
+            <option value="Viewer">Viewer</option>
+          </Select>
+        </div>
+
+        <div class="space-y-2 max-h-64 overflow-y-auto">
+          {teamMembers.map((member) => (
+            <div
+              class="grid grid-cols-[auto_1fr_1fr_auto_auto_auto] items-center gap-2 border p-2 rounded"
+              key={member.Email}
+            >
+              <input
+                type="checkbox"
+                checked={selected.includes(member.Email)}
+                onChange={() => toggleSelected(member.Email)}
+              />
+              <div class="text-sm">
+                {member.Name ?? 'N/A'}
+              </div>
+              <div class="text-sm">{member.Email}</div>
+              <Select
+                value={member.Role}
+                onChange={(e: JSX.TargetedEvent<HTMLSelectElement, Event>) =>
+                  updateMemberRole(
+                    member.Email,
+                    (e.target as HTMLSelectElement).value as
+                      | 'Owner'
+                      | 'Editor'
+                      | 'Viewer',
+                  )
+                }
+              >
+                <option>Owner</option>
+                <option>Editor</option>
+                <option>Viewer</option>
+              </Select>
+              <div class="text-sm">
+                {friendlyDate(member.Joined)}
+              </div>
+              <Action
+                onClick={() => removeMember(member.Email)}
+                intentType={IntentTypes.Error}
+                styleType={ActionStyleTypes.Icon}
+              >
+                ✖
+              </Action>
+            </div>
+          ))}
+        </div>
+
+        <div class="space-y-2 pt-4">
+          <div class="text-sm text-neutral-300 font-medium">
+            Invite New Team Member
+          </div>
+          <div class="flex items-center gap-2">
+            <Input
+              placeholder="Name (optional)"
+              value={name}
+              onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) =>
+                setName((e.target as HTMLInputElement).value)
+              }
+            />
+            <Input
+              placeholder="Email"
+              value={email}
+              onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) =>
+                setEmail((e.target as HTMLInputElement).value)
+              }
+            />
+            <Select
+              value={role}
+              onChange={(e: JSX.TargetedEvent<HTMLSelectElement, Event>) =>
+                setRole(
+                  (e.target as HTMLSelectElement)
+                    .value as 'Owner' | 'Editor' | 'Viewer',
+                )
+              }
+            >
+              <option value="Viewer">Viewer</option>
+              <option value="Editor">Editor</option>
+              <option value="Owner">Owner</option>
+            </Select>
+            <Action
+              onClick={() => {
+                inviteMember(email, role, name);
+                setName('');
+                setEmail('');
+                setRole('Viewer');
+              }}
+            >
+              Invite
+            </Action>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+TeamManagementModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <TeamManagementModal
+            workspaceMgr={workspaceMgr}
+            onClose={() => setShow(false)}
+          />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};

--- a/src/flow/managers/TeamManager.ts
+++ b/src/flow/managers/TeamManager.ts
@@ -6,9 +6,21 @@ export class TeamManager {
   protected listeners: (() => void)[] = [];
 
   constructor(initialMembers?: TeamMember[]) {
+    const joined = new Date().toISOString();
+
     this.members = initialMembers ?? [
-      { Email: 'admin@factory.com', Role: 'Owner' },
-      { Email: 'engineer@factory.com', Role: 'Editor' },
+      {
+        Email: 'admin@factory.com',
+        Role: 'Owner',
+        Name: 'Admin',
+        Joined: joined,
+      },
+      {
+        Email: 'engineer@factory.com',
+        Role: 'Editor',
+        Name: 'Engineer',
+        Joined: joined,
+      },
     ];
   }
 
@@ -16,11 +28,29 @@ export class TeamManager {
     return [...this.members];
   }
 
-  public InviteUser(email: string, role: string = 'Viewer'): void {
+  public InviteUser(
+    email: string,
+    role: TeamMember['Role'] = 'Viewer',
+    name?: string,
+  ): void {
     if (!email || this.members.some((m) => m.Email === email)) return;
 
-    this.members.push({ Email: email, Role: role });
+    this.members.push({
+      Email: email,
+      Role: role,
+      Name: name,
+      Joined: new Date().toISOString(),
+    });
+
     this.emitChange();
+  }
+
+  public UpdateUserRole(email: string, role: TeamMember['Role']): void {
+    const member = this.members.find((m) => m.Email === email);
+    if (member && member.Role !== role) {
+      member.Role = role;
+      this.emitChange();
+    }
   }
 
   public RemoveUser(email: string): void {

--- a/src/flow/types/TeamMember.ts
+++ b/src/flow/types/TeamMember.ts
@@ -1,5 +1,9 @@
 export type TeamMember = {
   Email: string;
 
-  Role: string;
+  Role: 'Owner' | 'Editor' | 'Viewer';
+
+  Name?: string;
+
+  Joined?: string;
 };


### PR DESCRIPTION
## Summary
- extract team management into new TeamManagementModal
- extend team types and managers with name, joined date, and role updates
- open team modal from workspace settings via Manage Team Members button

## Testing
- `deno task test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68961b16ed3c83268d72eaa188508120