### PR TITLE
feat: add API and billing placeholder modals

### DIFF
--- a/atomic/organisms/modals/.exports.ts
+++ b/atomic/organisms/modals/.exports.ts
@@ -3,3 +3,7 @@ export * from "./SimulatorLibraryModal.tsx";
 export * from "./WorkspaceSettingsModal.tsx";
 export * from "./TeamManagementModal.tsx";
 export * from "./ManageWorkspacesModal.tsx";
+export * from "./WarmQueryAPIsModal.tsx";
+export * from "./DataAPISuiteModal.tsx";
+export * from "./BillingDetailsModal.tsx";
+export * from "./CurrentLicenseModal.tsx";

--- a/atomic/organisms/modals/AccountProfileModal.tsx
+++ b/atomic/organisms/modals/AccountProfileModal.tsx
@@ -1,7 +1,7 @@
 import {
   AccountProfile,
   TeamMembership,
-} from '../../../src/flow/managers/WorkspaceManager.ts';
+} from '../../../src/flow/managers/WorkspaceManager.tsx';
 import { JSX, IntentTypes, useState, WorkspaceManager } from '../../.deps.ts';
 import {
   Modal,

--- a/atomic/organisms/modals/BillingDetailsModal.tsx
+++ b/atomic/organisms/modals/BillingDetailsModal.tsx
@@ -1,0 +1,78 @@
+import { JSX, WorkspaceManager, useState } from "../../.deps.ts";
+import { Modal, Action, ActionStyleTypes } from "../../.exports.ts";
+
+export type BillingDetailsModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function BillingDetailsModal({
+  workspaceMgr,
+  onClose,
+}: BillingDetailsModalProps): JSX.Element {
+  void workspaceMgr;
+
+  return (
+    <Modal title="Billing Details" onClose={onClose}>
+      <div class="space-y-6 text-sm">
+        {/* Subscription Summary */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Subscription Summary</h3>
+          <p>Plan: <strong>Basic (placeholder)</strong></p>
+          <p>Renewal Date: 2025-01-01</p>
+          <p>Price: $0/mo</p>
+          <p>Status: Active</p>
+        </section>
+
+        {/* Billing History */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Billing History</h3>
+          <table class="w-full text-left border-collapse">
+            <thead>
+              <tr class="border-b border-neutral-700">
+                <th class="p-2">Date</th>
+                <th class="p-2">Description</th>
+                <th class="p-2">Amount</th>
+                <th class="p-2">Status</th>
+                <th class="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-neutral-800">
+                <td class="p-2">2024-01-01</td>
+                <td class="p-2">Starter Plan</td>
+                <td class="p-2">$0.00</td>
+                <td class="p-2">Paid</td>
+                <td class="p-2 space-x-2">
+                  <Action styleType={ActionStyleTypes.Link} onClick={() => {}}>View Invoice</Action>
+                  <Action styleType={ActionStyleTypes.Link} onClick={() => {}}>Download Receipt</Action>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </div>
+
+      {/* TODO: integrate OpenIndustrialAPIClient.Billing.GetHistory() for real data */}
+    </Modal>
+  );
+}
+
+BillingDetailsModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <BillingDetailsModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default BillingDetailsModal;

--- a/atomic/organisms/modals/CurrentLicenseModal.tsx
+++ b/atomic/organisms/modals/CurrentLicenseModal.tsx
@@ -1,0 +1,106 @@
+import { JSX, WorkspaceManager, useState, IntentTypes } from "../../.deps.ts";
+import { Modal, Action, ActionStyleTypes } from "../../.exports.ts";
+
+export type CurrentLicenseModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function CurrentLicenseModal({
+  workspaceMgr,
+  onClose,
+}: CurrentLicenseModalProps): JSX.Element {
+  void workspaceMgr;
+
+  const license: {
+    name: string;
+    price: string;
+    features: string[];
+  } | null = null; // Placeholder; real license info will be loaded later
+
+  const plans = [
+    { id: "basic", name: "Basic", price: "$0/mo", features: ["1 workspace", "Community support"] },
+    {
+      id: "pro",
+      name: "Pro",
+      price: "$29/mo",
+      features: ["Unlimited workspaces", "Email support", "Advanced APIs"],
+    },
+    {
+      id: "enterprise",
+      name: "Enterprise",
+      price: "Contact us",
+      features: ["All Pro features", "Dedicated support", "Custom SLAs"],
+    },
+  ];
+
+  return (
+    <Modal title="Current License" onClose={onClose}>
+      <div class="space-y-6 text-sm">
+        {license ? (
+          <section>
+            <h3 class="text-lg font-semibold mb-2">Current Plan</h3>
+            <div class="border border-neutral-700 rounded p-4">
+              <p class="font-semibold">{license.name}</p>
+              <p class="text-neutral-400">{license.price}</p>
+              <ul class="list-disc list-inside mt-2">
+                {license.features.map((f) => <li key={f}>{f}</li>)}
+              </ul>
+            </div>
+          </section>
+        ) : (
+          <section class="space-y-3">
+            <p>No active license found. A license is required to access billing and API features.</p>
+            <Action intentType={IntentTypes.Primary} onClick={() => {}}>
+              Purchase License
+            </Action>
+          </section>
+        )}
+
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Available Plans</h3>
+          <div class="grid gap-4 md:grid-cols-3">
+            {plans.map((p) => (
+              <div key={p.id} class="border border-neutral-700 rounded p-4 flex flex-col gap-2">
+                <p class="font-semibold">{p.name}</p>
+                <p class="text-neutral-400">{p.price}</p>
+                <ul class="list-disc list-inside flex-1">
+                  {p.features.map((f) => <li key={f}>{f}</li>)}
+                </ul>
+                <Action
+                  onClick={() => {}}
+                  styleType={ActionStyleTypes.Outline}
+                  intentType={IntentTypes.Primary}
+                  class="mt-2"
+                >
+                  {license?.name === p.name ? "Selected" : "Select"}
+                </Action>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {/* TODO: integrate OpenIndustrialAPIClient.Licenses.List() and Update() */}
+    </Modal>
+  );
+}
+
+CurrentLicenseModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <CurrentLicenseModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default CurrentLicenseModal;

--- a/atomic/organisms/modals/DataAPISuiteModal.tsx
+++ b/atomic/organisms/modals/DataAPISuiteModal.tsx
@@ -1,0 +1,87 @@
+import { JSX, WorkspaceManager, useState } from "../../.deps.ts";
+import { Modal, Action, ActionStyleTypes } from "../../.exports.ts";
+
+export type DataAPISuiteModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function DataAPISuiteModal({
+  workspaceMgr,
+  onClose,
+}: DataAPISuiteModalProps): JSX.Element {
+  void workspaceMgr;
+
+  return (
+    <Modal title="Data API Suite" onClose={onClose}>
+      <div class="space-y-6 text-sm">
+        {/* Data Connections Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Data Connections</h3>
+          <ul class="list-disc list-inside space-y-1">
+            <li>IoT Hub 1 (placeholder)</li>
+            <li>IoT Hub 2 (placeholder)</li>
+          </ul>
+        </section>
+
+        {/* Schemas Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Schemas</h3>
+          <p>Schema listings coming soon...</p>
+        </section>
+
+        {/* Surfaces Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Surfaces</h3>
+          <p>Surface listings coming soon...</p>
+        </section>
+
+        {/* API Keys & Endpoints Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">API Keys &amp; Endpoints</h3>
+          <div class="space-y-2">
+            <div class="flex items-center gap-2">
+              <code class="flex-1">api-key-placeholder</code>
+              <Action
+                styleType={ActionStyleTypes.Outline}
+                onClick={() => navigator.clipboard.writeText("api-key-placeholder")}
+              >
+                Copy Key
+              </Action>
+            </div>
+            <div class="flex items-center gap-2">
+              <code class="flex-1">https://api.example.com</code>
+              <Action
+                styleType={ActionStyleTypes.Outline}
+                onClick={() => navigator.clipboard.writeText("https://api.example.com")}
+              >
+                Copy URL
+              </Action>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* TODO: hook up real data connections, schemas, surfaces, and API keys via workspaceMgr */}
+    </Modal>
+  );
+}
+
+DataAPISuiteModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <DataAPISuiteModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default DataAPISuiteModal;

--- a/atomic/organisms/modals/WarmQueryAPIsModal.tsx
+++ b/atomic/organisms/modals/WarmQueryAPIsModal.tsx
@@ -1,0 +1,39 @@
+import { JSX, WorkspaceManager, useState } from "../../.deps.ts";
+import { Modal } from "../../.exports.ts";
+
+export type WarmQueryAPIsModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function WarmQueryAPIsModal({
+  workspaceMgr,
+  onClose,
+}: WarmQueryAPIsModalProps): JSX.Element {
+  void workspaceMgr;
+
+  return (
+    <Modal title="Warm Query APIs" onClose={onClose}>
+      <p>Coming soon...</p>
+    </Modal>
+  );
+}
+
+WarmQueryAPIsModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <WarmQueryAPIsModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default WarmQueryAPIsModal;

--- a/src/flow/managers/.exports.ts
+++ b/src/flow/managers/.exports.ts
@@ -9,4 +9,4 @@ export * from './NodeEventManager.ts';
 export * from './SelectionManager.ts';
 export * from './SimulatorLibraryManager.ts';
 export * from './TeamManager.ts';
-export * from './WorkspaceManager.ts';
+export * from './WorkspaceManager.tsx';

--- a/src/flow/managers/NodeEventManager.ts
+++ b/src/flow/managers/NodeEventManager.ts
@@ -1,4 +1,4 @@
-import { WorkspaceManager } from './WorkspaceManager.ts';
+import { WorkspaceManager } from './WorkspaceManager.tsx';
 import { NodeEvent } from '../types/nodes/NodeEventRouter.ts';
 
 export class NodeEventManager {

--- a/src/flow/managers/WorkspaceManager.tsx
+++ b/src/flow/managers/WorkspaceManager.tsx
@@ -273,6 +273,60 @@ export class WorkspaceManager {
     };
   }
 
+  public UseAppMenu() {
+    const { Modal: accProfModal, Show: showAccProf } =
+      AccountProfileModal.Modal(this);
+    const { Modal: mngWkspsModal, Show: showMngWksps } =
+      ManageWorkspacesModal.Modal(this);
+    const { Modal: simLibModal, Show: showSimLib } =
+      SimulatorLibraryModal.Modal(this);
+    const { Modal: teamMgmtModal, Show: showTeamMgmt } =
+      TeamManagementModal.Modal(this);
+    const { Modal: wkspSetsModal, Show: showWkspSets } =
+      WorkspaceSettingsModal.Modal(this);
+
+    const modals = (
+      <>
+        {simLibModal}
+        {accProfModal}
+        {mngWkspsModal}
+        {teamMgmtModal}
+        {wkspSetsModal}
+      </>
+    );
+
+    const handleMenu = (item: MenuActionItem) => {
+      console.log('menu', item);
+
+      switch (item.id) {
+        case 'workspace.settings': {
+          showWkspSets();
+          break;
+        }
+
+        case 'workspace.team': {
+          showTeamMgmt();
+          break;
+        }
+
+        case 'workspace.viewAll': {
+          showMngWksps();
+          break;
+        }
+      }
+    };
+
+    return {
+      handleMenu,
+      modals,
+      showWkspSets,
+      showTeamMgmt,
+      showSimLib,
+      showMngWksps,
+      showAccProf,
+    };
+  }
+
   public UseAzi(): {
     state: AziState;
     isSending: boolean;
@@ -394,60 +448,6 @@ export class WorkspaceManager {
     }, [eac?.Details?.Name, currentScope]);
 
     return pathParts;
-  }
-
-  public UseAppMenu() {
-    const { Modal: accProfModal, Show: showAccProf } =
-      AccountProfileModal.Modal(this);
-    const { Modal: mngWkspsModal, Show: showMngWksps } =
-      ManageWorkspacesModal.Modal(this);
-    const { Modal: simLibModal, Show: showSimLib } =
-      SimulatorLibraryModal.Modal(this);
-    const { Modal: teamMgmtModal, Show: showTeamMgmt } =
-      TeamManagementModal.Modal(this);
-    const { Modal: wkspSetsModal, Show: showWkspSets } =
-      WorkspaceSettingsModal.Modal(this);
-
-    const modals = (
-      <>
-        {simLibModal}
-        {accProfModal}
-        {mngWkspsModal}
-        {teamMgmtModal}
-        {wkspSetsModal}
-      </>
-    );
-
-    const handleMenu = (item: MenuActionItem) => {
-      console.log('menu', item);
-
-      switch (item.id) {
-        case 'workspace.settings': {
-          showWkspSets();
-          break;
-        }
-
-        case 'workspace.team': {
-          showTeamMgmt();
-          break;
-        }
-
-        case 'workspace.viewAll': {
-          showMngWksps();
-          break;
-        }
-      }
-    };
-
-    return {
-      handleMenu,
-      modals,
-      showWkspSets,
-      showTeamMgmt,
-      showSimLib,
-      showMngWksps,
-      showAccProf,
-    };
   }
 
   public UseEaC(): EverythingAsCodeOIWorkspace {

--- a/src/flow/managers/WorkspaceManager.tsx
+++ b/src/flow/managers/WorkspaceManager.tsx
@@ -18,37 +18,43 @@ import {
   useRef,
   useState,
   XYPosition,
-} from "../.deps.ts";
+} from '../.deps.ts';
 
-import { FlowNodeData } from "../types/react/FlowNodeData.ts";
-import { GraphStateManager } from "./GraphStateManager.ts";
+import { FlowNodeData } from '../types/react/FlowNodeData.ts';
+import { GraphStateManager } from './GraphStateManager.ts';
 import {
   ImpulseStreamFilter,
   ImpulseStreamManager,
-} from "./ImpulseStreamManager.ts";
-import { InteractionManager } from "./InteractionManager.ts";
-import { SelectionManager } from "./SelectionManager.ts";
-import { AziManager, AziState } from "./AziManager.ts";
-import { SimulatorLibraryManager } from "./SimulatorLibraryManager.ts";
-import { EaCManager } from "./EaCManager.ts";
-import { NodeScopeTypes } from "../types/graph/NodeScopeTypes.ts";
-import { EverythingAsCodeOIWorkspace } from "../../eac/EverythingAsCodeOIWorkspace.ts";
-import { HistoryManager } from "./HistoryManager.ts";
-import { TeamManager } from "./TeamManager.ts";
-import { NodeEventManager } from "./NodeEventManager.ts";
-import { InspectorCommonProps } from "../types/nodes/InspectorCommonProps.ts";
-import { WorkspaceSummary } from "../types/WorkspaceSummary.ts";
-import { TeamMember } from "../types/TeamMember.ts";
-import { BreadcrumbPart } from "../types/BreadcrumbPart.ts";
-import { IntentTypes } from "../../types/IntentTypes.ts";
-import { EaCNodeCapabilityManager, NodePreset } from "../.exports.ts";
-import { OpenIndustrialAPIClient } from "../../api/clients/OpenIndustrialAPIClient.ts";
+} from './ImpulseStreamManager.ts';
+import { InteractionManager } from './InteractionManager.ts';
+import { SelectionManager } from './SelectionManager.ts';
+import { AziManager, AziState } from './AziManager.ts';
+import { SimulatorLibraryManager } from './SimulatorLibraryManager.ts';
+import { EaCManager } from './EaCManager.ts';
+import { NodeScopeTypes } from '../types/graph/NodeScopeTypes.ts';
+import { EverythingAsCodeOIWorkspace } from '../../eac/EverythingAsCodeOIWorkspace.ts';
+import { HistoryManager } from './HistoryManager.ts';
+import { TeamManager } from './TeamManager.ts';
+import { NodeEventManager } from './NodeEventManager.ts';
+import { InspectorCommonProps } from '../types/nodes/InspectorCommonProps.ts';
+import { WorkspaceSummary } from '../types/WorkspaceSummary.ts';
+import { TeamMember } from '../types/TeamMember.ts';
+import { BreadcrumbPart } from '../types/BreadcrumbPart.ts';
+import { IntentTypes } from '../../types/IntentTypes.ts';
+import { EaCNodeCapabilityManager, NodePreset } from '../.exports.ts';
+import { OpenIndustrialAPIClient } from '../../api/clients/OpenIndustrialAPIClient.ts';
 import {
   RuntimeImpulse,
   RuntimeImpulseSources,
-} from "../../types/RuntimeImpulse.ts";
-import { IntentStyleMap } from "../../../atomic/utils/getIntentStyles.ts";
-import { impulseSourceColorMap } from "../../../atomic/utils/impulseSourceColorMap.ts";
+} from '../../types/RuntimeImpulse.ts';
+import { IntentStyleMap } from '../../../atomic/utils/getIntentStyles.ts';
+import { impulseSourceColorMap } from '../../../atomic/utils/impulseSourceColorMap.ts';
+import { WorkspaceSettingsModal } from '../../../atomic/organisms/modals/WorkspaceSettingsModal.tsx';
+import { TeamManagementModal } from '../../../atomic/organisms/modals/TeamManagementModal.tsx';
+import { SimulatorLibraryModal } from '../../../atomic/organisms/modals/SimulatorLibraryModal.tsx';
+import { ManageWorkspacesModal } from '../../../atomic/organisms/modals/ManageWorkspacesModal.tsx';
+import { AccountProfileModal } from '../../../atomic/organisms/modals/AccountProfileModal.tsx';
+import { MenuActionItem } from '../../../atomic/molecules/FlyoutMenu.tsx';
 
 export type AccountProfile = {
   Name: string;
@@ -67,7 +73,7 @@ export type AccountProfile = {
 export type TeamMembership = {
   Lookup: string; // team id
   Team: string; // team display name
-  Role: "Owner" | "Editor" | "Viewer";
+  Role: 'Owner' | 'Editor' | 'Viewer';
   MemberSince: string; // friendly text
 };
 
@@ -93,9 +99,9 @@ export class WorkspaceManager {
     eac: EverythingAsCodeOIWorkspace,
     protected oiSvc: OpenIndustrialAPIClient,
     capabilitiesByScope: Record<NodeScopeTypes, EaCNodeCapabilityManager[]>,
-    scope: NodeScopeTypes = "workspace",
+    scope: NodeScopeTypes = 'workspace',
     aziCircuitUrl: string,
-    jwt?: string,
+    jwt?: string
   ) {
     this.currentScope = { Scope: scope };
 
@@ -118,7 +124,7 @@ export class WorkspaceManager {
     this.Graph = new GraphStateManager(
       this.Interaction,
       (id: string) => this.UseStats(id),
-      this.NodeEvents,
+      this.NodeEvents
     );
 
     this.EaC = new EaCManager(
@@ -127,12 +133,12 @@ export class WorkspaceManager {
       this.currentScope.Scope,
       this.Graph,
       this.History,
-      capabilitiesByScope,
+      capabilitiesByScope
     );
 
     this.Interaction.BindEaCManager(this.EaC);
 
-    console.log("🚀 FlowManager initialized:", {
+    console.log('🚀 FlowManager initialized:', {
       scope: this.currentScope,
       nodes: this.Graph.GetNodes().length,
       edges: this.Graph.GetEdges().length,
@@ -140,8 +146,6 @@ export class WorkspaceManager {
   }
 
   // === Hooks ===
-
-  public UseAppMenu() {}
 
   public UseAccountProfile(): {
     profile: AccountProfile;
@@ -152,7 +156,7 @@ export class WorkspaceManager {
     setProfile: (next: Partial<AccountProfile>) => void;
     setAvatarUrl: (url: string) => void;
 
-    updateTeamRole: (teamLookup: string, role: TeamMembership["Role"]) => void;
+    updateTeamRole: (teamLookup: string, role: TeamMembership['Role']) => void;
     leaveTeam: (teamLookup: string) => void;
 
     save: () => Promise<void>;
@@ -161,16 +165,16 @@ export class WorkspaceManager {
   } {
     // Seed mock profile (hydrate from API in real impl)
     const initial: AccountProfile = {
-      Name: "Jane Doe",
-      Email: "jane.doe@factory.com",
-      Username: "jane_d",
-      AvatarUrl: "",
-      Bio: "",
-      Location: "",
-      Website: "",
-      Additional: "",
-      CreatedAt: "2025-07-01",
-      ID: "user_123",
+      Name: 'Jane Doe',
+      Email: 'jane.doe@factory.com',
+      Username: 'jane_d',
+      AvatarUrl: '',
+      Bio: '',
+      Location: '',
+      Website: '',
+      Additional: '',
+      CreatedAt: '2025-07-01',
+      ID: 'user_123',
     };
 
     const [profile, setProfileState] = useState<AccountProfile>(initial);
@@ -179,22 +183,22 @@ export class WorkspaceManager {
     // Mock teams (swap to this.Team?.ListTeams?.() later)
     const [teams, setTeams] = useState<TeamMembership[]>([
       {
-        Lookup: "a",
-        Team: "Team A",
-        Role: "Viewer",
-        MemberSince: "2 days ago",
+        Lookup: 'a',
+        Team: 'Team A',
+        Role: 'Viewer',
+        MemberSince: '2 days ago',
       },
       {
-        Lookup: "b",
-        Team: "Team B",
-        Role: "Editor",
-        MemberSince: "1 month ago",
+        Lookup: 'b',
+        Team: 'Team B',
+        Role: 'Editor',
+        MemberSince: '1 month ago',
       },
       {
-        Lookup: "c",
-        Team: "Team C",
-        Role: "Owner",
-        MemberSince: "2 months ago",
+        Lookup: 'c',
+        Team: 'Team C',
+        Role: 'Owner',
+        MemberSince: '2 months ago',
       },
     ]);
 
@@ -208,10 +212,10 @@ export class WorkspaceManager {
 
     const updateTeamRole = (
       teamLookup: string,
-      role: TeamMembership["Role"],
+      role: TeamMembership['Role']
     ) => {
       setTeams((prev) =>
-        prev.map((t) => (t.Lookup === teamLookup ? { ...t, Role: role } : t)),
+        prev.map((t) => (t.Lookup === teamLookup ? { ...t, Role: role } : t))
       );
     };
 
@@ -223,10 +227,10 @@ export class WorkspaceManager {
     // --- Persistence (mock)
     const save = async () => {
       const { Password: _pw, ...persistable } = profile;
-      console.log("💾 [UseAccountProfile] saving profile →", persistable);
+      console.log('💾 [UseAccountProfile] saving profile →', persistable);
 
       if (profile.Password) {
-        console.log("🔐 [UseAccountProfile] updating password (mock)…");
+        console.log('🔐 [UseAccountProfile] updating password (mock)…');
         // await this.oiSvc.Users.UpdatePassword(profile.Password)
       }
 
@@ -235,21 +239,21 @@ export class WorkspaceManager {
     };
 
     const signOut = async () => {
-      console.log("Signing out...");
+      console.log('Signing out...');
     };
 
     const deleteAccount = async () => {
-      const ok1 = confirm("Permanently delete your account? There is no undo.");
+      const ok1 = confirm('Permanently delete your account? There is no undo.');
       const ok2 =
         ok1 &&
         confirm(
-          "Workspaces owned solely by this account will be lost. Continue?",
+          'Workspaces owned solely by this account will be lost. Continue?'
         );
       if (!ok2) return;
 
       // await this.oiSvc.Users.DeleteMyAccount()
-      console.warn("🗑️ [UseAccountProfile] account deleted (mock)");
-      location.assign("/"); // simulate sign-out
+      console.warn('🗑️ [UseAccountProfile] account deleted (mock)');
+      location.assign('/'); // simulate sign-out
     };
 
     return {
@@ -287,11 +291,11 @@ export class WorkspaceManager {
 
     const animateScroll = (container: HTMLDivElement) => {
       requestAnimationFrame(() => {
-        container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+        container.scrollTo({ top: container.scrollHeight, behavior: 'auto' });
 
         console.log(
-          "[UseAzi] ✅ Initial scroll to bottom:",
-          container.scrollHeight,
+          '[UseAzi] ✅ Initial scroll to bottom:',
+          container.scrollHeight
         );
       });
     };
@@ -300,17 +304,17 @@ export class WorkspaceManager {
     useLayoutEffect(() => {
       const container = scrollRef.current;
       if (!container) {
-        console.log("[UseAzi] ❌ No scroll container");
+        console.log('[UseAzi] ❌ No scroll container');
         return;
       }
 
       if (hasScrolledInitially.current) {
-        console.log("[UseAzi] ⚠️ Already scrolled initially — skipping");
+        console.log('[UseAzi] ⚠️ Already scrolled initially — skipping');
         return;
       }
 
       if (state.Messages.length <= 1) {
-        console.log("[UseAzi] ⏳ No messages yet — waiting");
+        console.log('[UseAzi] ⏳ No messages yet — waiting');
         return;
       }
 
@@ -359,14 +363,14 @@ export class WorkspaceManager {
     const { currentScope, currentScopeData } = this.UseScopeSwitcher();
 
     const [pathParts, setPathParts] = useState<BreadcrumbPart[]>([
-      { label: "Loading...", intentType: IntentTypes.Info },
-      { label: "Workspace", intentType: IntentTypes.Primary },
+      { label: 'Loading...', intentType: IntentTypes.Info },
+      { label: 'Workspace', intentType: IntentTypes.Primary },
     ]);
 
     useEffect(() => {
-      const name = eac?.Details?.Name ?? "Loading...";
+      const name = eac?.Details?.Name ?? 'Loading...';
 
-      if (currentScope === "workspace") {
+      if (currentScope === 'workspace') {
         setPathParts([
           {
             label: `${name} (Workspace)`,
@@ -375,12 +379,12 @@ export class WorkspaceManager {
       } else {
         const surfaceLookup = currentScopeData.Lookup!;
         const surfaceName =
-          eac.Surfaces?.[surfaceLookup]?.Details?.Name ?? "Unknown Surface";
+          eac.Surfaces?.[surfaceLookup]?.Details?.Name ?? 'Unknown Surface';
 
         setPathParts([
           {
             label: `${name} (Workspace)`,
-            onClick: () => this.SwitchToScope("workspace"),
+            onClick: () => this.SwitchToScope('workspace'),
           },
           {
             label: `${surfaceName} (Surface)`,
@@ -390,6 +394,60 @@ export class WorkspaceManager {
     }, [eac?.Details?.Name, currentScope]);
 
     return pathParts;
+  }
+
+  public UseAppMenu() {
+    const { Modal: accProfModal, Show: showAccProf } =
+      AccountProfileModal.Modal(this);
+    const { Modal: mngWkspsModal, Show: showMngWksps } =
+      ManageWorkspacesModal.Modal(this);
+    const { Modal: simLibModal, Show: showSimLib } =
+      SimulatorLibraryModal.Modal(this);
+    const { Modal: teamMgmtModal, Show: showTeamMgmt } =
+      TeamManagementModal.Modal(this);
+    const { Modal: wkspSetsModal, Show: showWkspSets } =
+      WorkspaceSettingsModal.Modal(this);
+
+    const modals = (
+      <>
+        {simLibModal}
+        {accProfModal}
+        {mngWkspsModal}
+        {teamMgmtModal}
+        {wkspSetsModal}
+      </>
+    );
+
+    const handleMenu = (item: MenuActionItem) => {
+      console.log('menu', item);
+
+      switch (item.id) {
+        case 'workspace.settings': {
+          showWkspSets();
+          break;
+        }
+
+        case 'workspace.team': {
+          showTeamMgmt();
+          break;
+        }
+
+        case 'workspace.viewAll': {
+          showMngWksps();
+          break;
+        }
+      }
+    };
+
+    return {
+      handleMenu,
+      modals,
+      showWkspSets,
+      showTeamMgmt,
+      showSimLib,
+      showMngWksps,
+      showAccProf,
+    };
   }
 
   public UseEaC(): EverythingAsCodeOIWorkspace {
@@ -437,7 +495,7 @@ export class WorkspaceManager {
     const [canUndo, setCanUndo] = useState(this.History.CanUndo());
     const [canRedo, setCanRedo] = useState(this.History.CanRedo());
     const [hasChanges, setHasChanges] = useState(
-      this.History.HasUnsavedChanges(),
+      this.History.HasUnsavedChanges()
     );
     const [version, setVersion] = useState(this.History.GetVersion());
 
@@ -458,14 +516,14 @@ export class WorkspaceManager {
       const handleBeforeUnload = (e: BeforeUnloadEvent) => {
         if (this.History.HasUnsavedChanges()) {
           e.preventDefault();
-          e.returnValue = ""; // Required for Chrome
+          e.returnValue = ''; // Required for Chrome
         }
       };
 
-      addEventListener("beforeunload", handleBeforeUnload);
+      addEventListener('beforeunload', handleBeforeUnload);
 
       return () => {
-        removeEventListener("beforeunload", handleBeforeUnload);
+        removeEventListener('beforeunload', handleBeforeUnload);
       };
     }, []);
 
@@ -542,7 +600,7 @@ export class WorkspaceManager {
           return merged;
         });
       },
-      [selectedId],
+      [selectedId]
     );
 
     const handleToggleEnabled = useCallback(
@@ -553,12 +611,12 @@ export class WorkspaceManager {
           });
 
           console.log(
-            `🟡 Toggled enabled state for node ${selectedId} → ${val}`,
+            `🟡 Toggled enabled state for node ${selectedId} → ${val}`
           );
           setEnabled(val);
         }
       },
-      [selectedId],
+      [selectedId]
     );
 
     const handleDeleteNode = useCallback(() => {
@@ -645,7 +703,7 @@ export class WorkspaceManager {
   public UseInteraction(): {
     handleDrop: (
       event: DragEvent,
-      toFlow: (point: XYPosition) => XYPosition,
+      toFlow: (point: XYPosition) => XYPosition
     ) => void;
     handleConnect: (params: Connection) => void;
     handleNodeClick: (_e: unknown, node: Node<FlowNodeData>) => void;
@@ -656,7 +714,7 @@ export class WorkspaceManager {
       (event: DragEvent, toFlow: (point: XYPosition) => XYPosition) => {
         this.Interaction.HandleDrop(event, this.Graph.GetNodes(), toFlow);
       },
-      [],
+      []
     );
 
     const handleConnect = useCallback((params: Connection) => {
@@ -669,21 +727,21 @@ export class WorkspaceManager {
       (_e: unknown, node: Node<FlowNodeData>) => {
         this.Selection.SelectNode(node.id);
       },
-      [],
+      []
     );
 
     const handleNodesChange = useCallback(
       (changes: NodeChange[], nodes: Node[]) => {
         this.Interaction.OnNodesChange(changes, nodes ?? this.Graph.GetNodes());
       },
-      [],
+      []
     );
 
     const handleEdgesChange = useCallback(
       (changes: EdgeChange[], edges: Edge[]) => {
         this.Interaction.OnEdgesChange(changes, edges ?? this.Graph.GetEdges());
       },
-      [],
+      []
     );
 
     return {
@@ -730,7 +788,7 @@ export class WorkspaceManager {
     setSelected: Dispatch<StateUpdater<Node<FlowNodeData> | null>>;
   } {
     const [selected, setSelected] = useState<Node<FlowNodeData> | null>(
-      this.Selection.GetSelectedNodes(this.Graph.GetNodes())[0] ?? null,
+      this.Selection.GetSelectedNodes(this.Graph.GetNodes())[0] ?? null
     );
 
     useEffect(() => {
@@ -749,7 +807,7 @@ export class WorkspaceManager {
 
   public UseStats<TStats extends Record<string, unknown>>(
     id: string,
-    intervalMs = 100000,
+    intervalMs = 100000
   ): TStats | undefined {
     const [stats, setStats] = useState<TStats>({} as TStats);
 
@@ -783,7 +841,7 @@ export class WorkspaceManager {
   } {
     const [presets, setPresets] = useState<Record<string, NodePreset>>({});
     const [nodeTypes, setNodeTypes] = useState<Record<string, ComponentType>>(
-      {},
+      {}
     );
 
     useEffect(() => {
@@ -793,7 +851,7 @@ export class WorkspaceManager {
           setPresets(capabilityMgr.GetPresets());
           setNodeTypes(capabilityMgr.GetRendererMap());
         } catch (err) {
-          console.warn("⚠️ EaC scopeMgr not ready yet in UseUIContext:", err);
+          console.warn('⚠️ EaC scopeMgr not ready yet in UseUIContext:', err);
           setPresets({});
           setNodeTypes({});
         }
@@ -819,11 +877,11 @@ export class WorkspaceManager {
     teamMembers: TeamMember[];
     inviteMember: (
       email: string,
-      role: TeamMember["Role"],
-      name?: string,
+      role: TeamMember['Role'],
+      name?: string
     ) => void;
     removeMember: (email: string) => void;
-    updateMemberRole: (email: string, role: TeamMember["Role"]) => void;
+    updateMemberRole: (email: string, role: TeamMember['Role']) => void;
     update: (next: Partial<EaCEnterpriseDetails>) => void;
     save: () => Promise<void>;
     archive: () => void;
@@ -846,10 +904,10 @@ export class WorkspaceManager {
     };
 
     const [current, setCurrent] = useState<WorkspaceSummary>(
-      getCurrentWorkspace(),
+      getCurrentWorkspace()
     );
     const [hasChanges, setHasChanges] = useState(
-      this.History.HasUnsavedChanges(),
+      this.History.HasUnsavedChanges()
     );
 
     useEffect(() => {
@@ -863,7 +921,7 @@ export class WorkspaceManager {
     }, []);
 
     const [teamMembers, setTeamMembers] = useState<TeamMember[]>(
-      this.Team?.ListUsers?.() ?? [],
+      this.Team?.ListUsers?.() ?? []
     );
 
     useEffect(() => {
@@ -895,17 +953,17 @@ export class WorkspaceManager {
     const save = () => {
       this.Commit();
 
-      console.log("💾 Saved workspace details");
+      console.log('💾 Saved workspace details');
 
       return Promise.resolve();
       // this.ReloadPacks();
     };
 
     const archive = () => {
-      const name = current.Details.Name ?? "this workspace";
+      const name = current.Details.Name ?? 'this workspace';
 
       const confirmed = confirm(
-        `Are you sure you want to archive ${name}? This will remove it from the current session.`,
+        `Are you sure you want to archive ${name}? This will remove it from the current session.`
       );
 
       if (!confirmed) return;
@@ -917,8 +975,8 @@ export class WorkspaceManager {
 
     const inviteMember = (
       email: string,
-      role: TeamMember["Role"],
-      name?: string,
+      role: TeamMember['Role'],
+      name?: string
     ) => {
       if (!email) return;
       this.Team?.InviteUser?.(email, role, name);
@@ -928,7 +986,7 @@ export class WorkspaceManager {
       this.Team?.RemoveUser?.(email);
     };
 
-    const updateMemberRole = (email: string, role: TeamMember["Role"]) => {
+    const updateMemberRole = (email: string, role: TeamMember['Role']) => {
       this.Team?.UpdateUserRole?.(email, role);
     };
 
@@ -970,7 +1028,7 @@ export class WorkspaceManager {
 
   public Fork(): void {
     const forked = this.History.ForkRuntime();
-    console.log("🌱 Forked runtime snapshot:", forked);
+    console.log('🌱 Forked runtime snapshot:', forked);
   }
 
   public HasUnsavedChanges(): boolean {
@@ -981,7 +1039,7 @@ export class WorkspaceManager {
     const snapshot = this.History.RevertToLastCommit();
     if (snapshot) {
       this.EaC.ResetFromSnapshot(snapshot);
-      console.log("🔄 Reverted to last commit");
+      console.log('🔄 Reverted to last commit');
     }
   }
 
@@ -989,7 +1047,7 @@ export class WorkspaceManager {
     const snapshot = this.History.Undo();
     if (snapshot) {
       this.EaC.ResetFromSnapshot(snapshot);
-      console.log("↩️ Undo successful");
+      console.log('↩️ Undo successful');
     }
   }
 
@@ -997,12 +1055,12 @@ export class WorkspaceManager {
     const snapshot = this.History.Redo();
     if (snapshot) {
       this.EaC.ResetFromSnapshot(snapshot);
-      console.log("↪️ Redo successful");
+      console.log('↪️ Redo successful');
     }
   }
 
   public ReloadCapabilities(
-    capabilitiesByScope: Record<NodeScopeTypes, EaCNodeCapabilityManager[]>,
+    capabilitiesByScope: Record<NodeScopeTypes, EaCNodeCapabilityManager[]>
   ): void {
     this.EaC.LoadCapabilities(capabilitiesByScope);
 

--- a/src/flow/managers/eac/EaCCapabilitiesManager.ts
+++ b/src/flow/managers/eac/EaCCapabilitiesManager.ts
@@ -10,7 +10,7 @@ import { EaCNodeCapabilityPatch } from '../../types/nodes/EaCNodeCapabilityPatch
 
 import { EaCNodeCapabilityManager } from './EaCNodeCapabilityManager.ts';
 import { NodePreset } from '../../types/react/NodePreset.ts';
-import { WorkspaceManager } from '../WorkspaceManager.ts';
+import { WorkspaceManager } from '../WorkspaceManager.tsx';
 import { NodeEventRouter } from '../../types/nodes/NodeEventRouter.ts';
 import { EverythingAsCodeOIWorkspace } from '../../../eac/EverythingAsCodeOIWorkspace.ts';
 import { Position } from '../../../eac/types/Position.ts';

--- a/src/flow/managers/eac/EaCNodeCapabilityManager.ts
+++ b/src/flow/managers/eac/EaCNodeCapabilityManager.ts
@@ -12,7 +12,7 @@ import { EaCNodeCapabilityContext } from '../../types/nodes/EaCNodeCapabilityCon
 import { EaCNodeCapabilityPatch } from '../../types/nodes/EaCNodeCapabilityPatch.ts';
 import { NodeEventRouter } from '../../types/nodes/NodeEventRouter.ts';
 import { NodePreset } from '../../types/react/NodePreset.ts';
-import { WorkspaceManager } from '../WorkspaceManager.ts';
+import { WorkspaceManager } from '../WorkspaceManager.tsx';
 
 /**
  * Abstract base class for managing scoped node capabilities in the EaC model.

--- a/src/flow/managers/node-events/SurfaceEventRouter.ts
+++ b/src/flow/managers/node-events/SurfaceEventRouter.ts
@@ -1,5 +1,5 @@
 import { NodeEvent, NodeEventRouter } from '../../types/nodes/NodeEventRouter.ts';
-import { WorkspaceManager } from '../WorkspaceManager.ts';
+import { WorkspaceManager } from '../WorkspaceManager.tsx';
 
 export class SurfaceEventRouter implements NodeEventRouter {
   constructor(protected workspace: WorkspaceManager) {}


### PR DESCRIPTION
## Summary
- scaffold Warm Query, Data API Suite, Billing Details, and Current License modals
- expose new modals via organisms exports

## Testing
- `deno fmt atomic/organisms/modals/WarmQueryAPIsModal.tsx ...` *(fails: command not found: deno)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: The requested URL returned error: 403)*
- `deno task check` *(fails: command not found: deno)*
- `deno task test` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_b_689635872b8483269fd5581cc6248b85