### PR TITLE
feat: add API and billing placeholder modals

### DIFF
--- a/atomic/organisms/modals/.exports.ts
+++ b/atomic/organisms/modals/.exports.ts
@@ -3,3 +3,7 @@ export * from "./SimulatorLibraryModal.tsx";
 export * from "./WorkspaceSettingsModal.tsx";
 export * from "./TeamManagementModal.tsx";
 export * from "./ManageWorkspacesModal.tsx";
+export * from "./WarmQueryAPIsModal.tsx";
+export * from "./DataAPISuiteModal.tsx";
+export * from "./BillingDetailsModal.tsx";
+export * from "./CurrentLicenseModal.tsx";

--- a/atomic/organisms/modals/BillingDetailsModal.tsx
+++ b/atomic/organisms/modals/BillingDetailsModal.tsx
@@ -1,0 +1,78 @@
+import { JSX, WorkspaceManager, useState } from "../../.deps.ts";
+import { Modal, Action, ActionStyleTypes } from "../../.exports.ts";
+
+export type BillingDetailsModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function BillingDetailsModal({
+  workspaceMgr,
+  onClose,
+}: BillingDetailsModalProps): JSX.Element {
+  void workspaceMgr;
+
+  return (
+    <Modal title="Billing Details" onClose={onClose}>
+      <div class="space-y-6 text-sm">
+        {/* Subscription Summary */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Subscription Summary</h3>
+          <p>Plan: <strong>Basic (placeholder)</strong></p>
+          <p>Renewal Date: 2025-01-01</p>
+          <p>Price: $0/mo</p>
+          <p>Status: Active</p>
+        </section>
+
+        {/* Billing History */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Billing History</h3>
+          <table class="w-full text-left border-collapse">
+            <thead>
+              <tr class="border-b border-neutral-700">
+                <th class="p-2">Date</th>
+                <th class="p-2">Description</th>
+                <th class="p-2">Amount</th>
+                <th class="p-2">Status</th>
+                <th class="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-neutral-800">
+                <td class="p-2">2024-01-01</td>
+                <td class="p-2">Starter Plan</td>
+                <td class="p-2">$0.00</td>
+                <td class="p-2">Paid</td>
+                <td class="p-2 space-x-2">
+                  <Action styleType={ActionStyleTypes.Link} onClick={() => {}}>View Invoice</Action>
+                  <Action styleType={ActionStyleTypes.Link} onClick={() => {}}>Download Receipt</Action>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </div>
+
+      {/* TODO: integrate OpenIndustrialAPIClient.Billing.GetHistory() for real data */}
+    </Modal>
+  );
+}
+
+BillingDetailsModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <BillingDetailsModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default BillingDetailsModal;

--- a/atomic/organisms/modals/CurrentLicenseModal.tsx
+++ b/atomic/organisms/modals/CurrentLicenseModal.tsx
@@ -1,0 +1,106 @@
+import { JSX, WorkspaceManager, useState, IntentTypes } from "../../.deps.ts";
+import { Modal, Action, ActionStyleTypes } from "../../.exports.ts";
+
+export type CurrentLicenseModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function CurrentLicenseModal({
+  workspaceMgr,
+  onClose,
+}: CurrentLicenseModalProps): JSX.Element {
+  void workspaceMgr;
+
+  const license: {
+    name: string;
+    price: string;
+    features: string[];
+  } | null = null; // Placeholder; real license info will be loaded later
+
+  const plans = [
+    { id: "basic", name: "Basic", price: "$0/mo", features: ["1 workspace", "Community support"] },
+    {
+      id: "pro",
+      name: "Pro",
+      price: "$29/mo",
+      features: ["Unlimited workspaces", "Email support", "Advanced APIs"],
+    },
+    {
+      id: "enterprise",
+      name: "Enterprise",
+      price: "Contact us",
+      features: ["All Pro features", "Dedicated support", "Custom SLAs"],
+    },
+  ];
+
+  return (
+    <Modal title="Current License" onClose={onClose}>
+      <div class="space-y-6 text-sm">
+        {license ? (
+          <section>
+            <h3 class="text-lg font-semibold mb-2">Current Plan</h3>
+            <div class="border border-neutral-700 rounded p-4">
+              <p class="font-semibold">{license.name}</p>
+              <p class="text-neutral-400">{license.price}</p>
+              <ul class="list-disc list-inside mt-2">
+                {license.features.map((f) => <li key={f}>{f}</li>)}
+              </ul>
+            </div>
+          </section>
+        ) : (
+          <section class="space-y-3">
+            <p>No active license found. A license is required to access billing and API features.</p>
+            <Action intentType={IntentTypes.Primary} onClick={() => {}}>
+              Purchase License
+            </Action>
+          </section>
+        )}
+
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Available Plans</h3>
+          <div class="grid gap-4 md:grid-cols-3">
+            {plans.map((p) => (
+              <div key={p.id} class="border border-neutral-700 rounded p-4 flex flex-col gap-2">
+                <p class="font-semibold">{p.name}</p>
+                <p class="text-neutral-400">{p.price}</p>
+                <ul class="list-disc list-inside flex-1">
+                  {p.features.map((f) => <li key={f}>{f}</li>)}
+                </ul>
+                <Action
+                  onClick={() => {}}
+                  styleType={ActionStyleTypes.Outline}
+                  intentType={IntentTypes.Primary}
+                  class="mt-2"
+                >
+                  {license?.name === p.name ? "Selected" : "Select"}
+                </Action>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {/* TODO: integrate OpenIndustrialAPIClient.Licenses.List() and Update() */}
+    </Modal>
+  );
+}
+
+CurrentLicenseModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <CurrentLicenseModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default CurrentLicenseModal;

--- a/atomic/organisms/modals/DataAPISuiteModal.tsx
+++ b/atomic/organisms/modals/DataAPISuiteModal.tsx
@@ -1,0 +1,87 @@
+import { JSX, WorkspaceManager, useState } from "../../.deps.ts";
+import { Modal, Action, ActionStyleTypes } from "../../.exports.ts";
+
+export type DataAPISuiteModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function DataAPISuiteModal({
+  workspaceMgr,
+  onClose,
+}: DataAPISuiteModalProps): JSX.Element {
+  void workspaceMgr;
+
+  return (
+    <Modal title="Data API Suite" onClose={onClose}>
+      <div class="space-y-6 text-sm">
+        {/* Data Connections Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Data Connections</h3>
+          <ul class="list-disc list-inside space-y-1">
+            <li>IoT Hub 1 (placeholder)</li>
+            <li>IoT Hub 2 (placeholder)</li>
+          </ul>
+        </section>
+
+        {/* Schemas Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Schemas</h3>
+          <p>Schema listings coming soon...</p>
+        </section>
+
+        {/* Surfaces Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">Surfaces</h3>
+          <p>Surface listings coming soon...</p>
+        </section>
+
+        {/* API Keys & Endpoints Section */}
+        <section>
+          <h3 class="text-lg font-semibold mb-2">API Keys &amp; Endpoints</h3>
+          <div class="space-y-2">
+            <div class="flex items-center gap-2">
+              <code class="flex-1">api-key-placeholder</code>
+              <Action
+                styleType={ActionStyleTypes.Outline}
+                onClick={() => navigator.clipboard.writeText("api-key-placeholder")}
+              >
+                Copy Key
+              </Action>
+            </div>
+            <div class="flex items-center gap-2">
+              <code class="flex-1">https://api.example.com</code>
+              <Action
+                styleType={ActionStyleTypes.Outline}
+                onClick={() => navigator.clipboard.writeText("https://api.example.com")}
+              >
+                Copy URL
+              </Action>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* TODO: hook up real data connections, schemas, surfaces, and API keys via workspaceMgr */}
+    </Modal>
+  );
+}
+
+DataAPISuiteModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <DataAPISuiteModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default DataAPISuiteModal;

--- a/atomic/organisms/modals/WarmQueryAPIsModal.tsx
+++ b/atomic/organisms/modals/WarmQueryAPIsModal.tsx
@@ -1,0 +1,39 @@
+import { JSX, WorkspaceManager, useState } from "../../.deps.ts";
+import { Modal } from "../../.exports.ts";
+
+export type WarmQueryAPIsModalProps = {
+  workspaceMgr: WorkspaceManager;
+  onClose: () => void;
+};
+
+export function WarmQueryAPIsModal({
+  workspaceMgr,
+  onClose,
+}: WarmQueryAPIsModalProps): JSX.Element {
+  void workspaceMgr;
+
+  return (
+    <Modal title="Warm Query APIs" onClose={onClose}>
+      <p>Coming soon...</p>
+    </Modal>
+  );
+}
+
+WarmQueryAPIsModal.Modal = (workspaceMgr: WorkspaceManager) => {
+  const [shown, setShow] = useState(false);
+
+  return {
+    Modal: (
+      <>
+        {shown && (
+          <WarmQueryAPIsModal workspaceMgr={workspaceMgr} onClose={() => setShow(false)} />
+        )}
+      </>
+    ),
+    Hide: () => setShow(false),
+    IsOpen: () => shown,
+    Show: () => setShow(true),
+  };
+};
+
+export default WarmQueryAPIsModal;

--- a/src/flow/managers/WorkspaceManager.ts
+++ b/src/flow/managers/WorkspaceManager.ts
@@ -49,6 +49,18 @@ import {
 } from "../../types/RuntimeImpulse.ts";
 import { IntentStyleMap } from "../../../atomic/utils/getIntentStyles.ts";
 import { impulseSourceColorMap } from "../../../atomic/utils/impulseSourceColorMap.ts";
+import {
+  AccountProfileModal,
+  BillingDetailsModal,
+  CurrentLicenseModal,
+  DataAPISuiteModal,
+  ManageWorkspacesModal,
+  SimulatorLibraryModal,
+  TeamManagementModal,
+  WarmQueryAPIsModal,
+  WorkspaceSettingsModal,
+} from "../../../atomic/organisms/modals/.exports.ts";
+import { MenuActionItem } from "../../../atomic/molecules/FlyoutMenu.tsx";
 
 export type AccountProfile = {
   Name: string;
@@ -141,7 +153,95 @@ export class WorkspaceManager {
 
   // === Hooks ===
 
-  public UseAppMenu() {}
+  public UseAppMenu() {
+    const { Modal: accProfModal, Show: showAccProf } =
+      AccountProfileModal.Modal(this);
+    const { Modal: mngWkspsModal, Show: showMngWksps } =
+      ManageWorkspacesModal.Modal(this);
+    const { Modal: simLibModal, Show: showSimLib } =
+      SimulatorLibraryModal.Modal(this);
+    const { Modal: teamMgmtModal, Show: showTeamMgmt } =
+      TeamManagementModal.Modal(this);
+    const { Modal: wkspSetsModal, Show: showWkspSets } =
+      WorkspaceSettingsModal.Modal(this);
+    const { Modal: warmQueryModal, Show: showWarmQuery } =
+      WarmQueryAPIsModal.Modal(this);
+    const { Modal: dataSuiteModal, Show: showDataSuite } =
+      DataAPISuiteModal.Modal(this);
+    const { Modal: billingModal, Show: showBilling } =
+      BillingDetailsModal.Modal(this);
+    const { Modal: licenseModal, Show: showLicense } =
+      CurrentLicenseModal.Modal(this);
+
+    const modals = (
+      <>
+        {simLibModal}
+        {accProfModal}
+        {mngWkspsModal}
+        {teamMgmtModal}
+        {wkspSetsModal}
+        {warmQueryModal}
+        {dataSuiteModal}
+        {billingModal}
+        {licenseModal}
+      </>
+    );
+
+    const handleMenu = (item: MenuActionItem) => {
+      console.log("menu", item);
+
+      switch (item.id) {
+        case "workspace.settings": {
+          showWkspSets();
+          break;
+        }
+
+        case "workspace.team": {
+          showTeamMgmt();
+          break;
+        }
+
+        case "workspace.viewAll": {
+          showMngWksps();
+          break;
+        }
+
+        case "apis.warmQuery": {
+          showWarmQuery();
+          break;
+        }
+
+        case "apis.dataSuite": {
+          showDataSuite();
+          break;
+        }
+
+        case "billing.details": {
+          showBilling();
+          break;
+        }
+
+        case "billing.license": {
+          showLicense();
+          break;
+        }
+      }
+    };
+
+    return {
+      handleMenu,
+      modals,
+      showWkspSets,
+      showTeamMgmt,
+      showSimLib,
+      showMngWksps,
+      showAccProf,
+      showWarmQuery,
+      showDataSuite,
+      showBilling,
+      showLicense,
+    };
+  }
 
   public UseAccountProfile(): {
     profile: AccountProfile;


### PR DESCRIPTION
## Summary
- scaffold Warm Query, Data API Suite, Billing Details, and Current License modals
- expose new modals via organisms exports
- wire API and billing modals into the WorkspaceManager's app menu

## Testing
- `deno fmt src/flow/managers/WorkspaceManager.ts atomic/organisms/modals/WarmQueryAPIsModal.tsx atomic/organisms/modals/DataAPISuiteModal.tsx atomic/organisms/modals/BillingDetailsModal.tsx atomic/organisms/modals/CurrentLicenseModal.tsx atomic/organisms/modals/.exports.ts` *(fails: command not found: deno)*
- `deno task check` *(fails: command not found: deno)*
- `deno task test` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_b_689635872b8483269fd5581cc6248b85