### PR TITLE
feat(workspaces): add commit status APIs

### DIFF
--- a/src/api/clients/.exports.ts
+++ b/src/api/clients/.exports.ts
@@ -1,2 +1,3 @@
 export * from './ClientHelperBridge.ts';
 export * from './OpenIndustrialAPIClient.ts';
+export * from './OpenIndustrialWorkspaceAPI.ts';

--- a/src/api/clients/OpenIndustrialWorkspaceAPI.ts
+++ b/src/api/clients/OpenIndustrialWorkspaceAPI.ts
@@ -51,6 +51,43 @@ export class OpenIndustrialWorkspaceAPI {
   }
 
   /**
+   * List the commit statuses for the current workspace.
+   */
+  public async ListCommitStatuses(): Promise<EaCStatus[]> {
+    const res = await fetch(this.bridge.url('/api/workspaces/commit/statuses'), {
+      method: 'GET',
+      headers: this.bridge.headers(),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to list commit statuses: ${res.status}`);
+    }
+
+    return await this.bridge.json(res);
+  }
+
+  /**
+   * Get the status for a specific commit in the current workspace.
+   *
+   * @param commitId - The ID of the commit to retrieve.
+   */
+  public async GetCommitStatus(commitId: string): Promise<EaCStatus> {
+    const res = await fetch(
+      this.bridge.url(`/api/workspaces/commit/status/${commitId}`),
+      {
+        method: 'GET',
+        headers: this.bridge.headers(),
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch commit status: ${res.status}`);
+    }
+
+    return await this.bridge.json(res);
+  }
+
+  /**
    * Create a new workspace from the given OpenIndustrial EaC configuration.
    */
   public async Create(


### PR DESCRIPTION
## Summary
- add methods to list commit statuses and fetch individual commit status
- export OpenIndustrialWorkspaceAPI for external use

## Testing
- `deno task test` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_b_689b523af0348326a95ab5644c1fabfa