### PR TITLE
feat: add commit state badge to AppFrameBar

### DIFF
--- a/atomic/molecules/AppFrameBar.tsx
+++ b/atomic/molecules/AppFrameBar.tsx
@@ -1,6 +1,6 @@
-import { GitCommitIcon } from '../../build/iconset/icons/GitCommitIcon.tsx';
 import { SettingsIcon } from '../../build/iconset/icons/SettingsIcon.tsx';
 import { UsersIcon } from '../../build/iconset/icons/UsersIcon.tsx';
+import { GitCommitIcon } from '../../build/iconset/icons/GitCommitIcon.tsx';
 import { JSX, classSet, IntentTypes } from '../.deps.ts';
 import { Action, ActionStyleTypes } from '../atoms/Action.tsx';
 import { MenuActionItem, MenuRoot } from './FlyoutMenu.tsx';
@@ -11,16 +11,22 @@ export type AppFrameBarProps = {
   onMenuOption: (item: MenuActionItem) => void;
   onActivateClick?: () => void;
   onCommitClick?: () => void;
+  commitBadgeState?: CommitBadgeState;
+  commitIconSrc?: string;
   onProfileClick?: () => void;
   onSettingsClick?: () => void;
   profileIntentType?: IntentTypes;
 };
+
+export type CommitBadgeState = 'error' | 'processing' | 'success';
 
 export function AppFrameBar({
   menus,
   onMenuOption,
   onActivateClick,
   onCommitClick,
+  commitBadgeState,
+  commitIconSrc,
   onProfileClick,
   onSettingsClick,
   profileIntentType = IntentTypes.Info,
@@ -77,7 +83,18 @@ export function AppFrameBar({
             styleType={ActionStyleTypes.Icon | ActionStyleTypes.Thin}
             intentType={IntentTypes.Primary}
           >
-            <GitCommitIcon class="w-4 h-4" />
+            <span class="-:relative -:block">
+              <GitCommitIcon src={commitIconSrc} class="-:w-4 -:h-4" />
+              {commitBadgeState === 'error' && (
+                <span class="-:absolute -:top-0 -:right-0 -:w-2 -:h-2 -:rounded-full -:bg-neon-red-500 -:translate-x-1/2 -:-translate-y-1/2" />
+              )}
+              {commitBadgeState === 'processing' && (
+                <span class="-:absolute -:top-0 -:right-0 -:w-2 -:h-2 -:rounded-full -:border-2 -:border-neon-blue-500 -:border-t-transparent -:animate-spin -:translate-x-1/2 -:-translate-y-1/2" />
+              )}
+              {commitBadgeState === 'success' && (
+                <span class="-:absolute -:top-0 -:right-0 -:text-green-500 -:text-[10px] -:translate-x-1/2 -:-translate-y-1/2">✓</span>
+              )}
+            </span>
           </Action>
         )}
 

--- a/build/iconset/icons/GitCommitIcon.tsx
+++ b/build/iconset/icons/GitCommitIcon.tsx
@@ -1,5 +1,5 @@
 import { Icon, IconProps, JSX } from "./icon.deps.ts";
 
-export function GitCommitIcon(props: IconProps): JSX.Element {
-  return <Icon {...props} src="/icons/iconset" icon="gitCommit" />;
+export function GitCommitIcon({ src, ...rest }: IconProps): JSX.Element {
+  return <Icon {...rest} src={src ?? '/icons/iconset'} icon="gitCommit" />;
 }


### PR DESCRIPTION
## Summary
- add customizable commit button with optional badge in `AppFrameBar`
- expose `CommitBadgeState` and new commit icon props
- ensure GitCommitIcon remains visible beneath commit-state badge

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `curl -fsSL https://deno.land/install.sh | sh -s -- -f` *(fails: 403)*
- `deno fmt atomic/molecules/AppFrameBar.tsx build/iconset/icons/GitCommitIcon.tsx` *(fails: command not found)*
- `deno lint atomic/molecules/AppFrameBar.tsx build/iconset/icons/GitCommitIcon.tsx` *(fails: command not found)*
- `deno test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b58ea57288326bfaedd7abd60f198