### PR TITLE
docs: describe commit indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # open-industrial-reference-architecture
+
+## Commit Indicator and Flyout
+
+This reference architecture includes a commit indicator that reflects the health of
+recent workspace commits. The indicator displays one of three states:
+
+- **success** – all commits have completed successfully
+- **processing** – at least one commit is still running
+- **error** – a commit ended in failure
+
+Selecting the indicator opens a flyout panel that lists recent commits and their
+statuses. The panel automatically polls for updates every four seconds and the
+polling interval is cleared when the panel is unmounted to avoid memory leaks.

--- a/tests/flow/.tests.ts
+++ b/tests/flow/.tests.ts
@@ -1,0 +1,2 @@
+import './useCommits.tests.ts';
+import './commitStatusPanel.tests.ts';

--- a/tests/flow/commitStatusPanel.tests.ts
+++ b/tests/flow/commitStatusPanel.tests.ts
@@ -1,0 +1,24 @@
+import { assertStringIncludes } from '../tests.deps.ts';
+import { h } from 'npm:preact@10.20.1';
+import render from 'npm:preact-render-to-string@6.2.1';
+import { CommitStatusPanel } from '../../atomic/organisms/CommitStatusPanel.tsx';
+import { EaCStatusProcessingTypes, type EaCStatus } from '../../src/flow/.deps.ts';
+
+Deno.test('CommitStatusPanel renders provided commits', () => {
+  const commits: EaCStatus[] = [
+    { ID: '1', Processing: EaCStatusProcessingTypes.COMPLETE } as EaCStatus,
+    { ID: '2', Processing: EaCStatusProcessingTypes.ERROR } as EaCStatus,
+  ];
+
+  const html = render(
+    h(CommitStatusPanel, {
+      commits,
+      selectedCommitId: '1',
+      onSelectCommit: () => {},
+      onClose: () => {},
+    }),
+  );
+
+  assertStringIncludes(html, '1');
+  assertStringIncludes(html, '2');
+});

--- a/tests/flow/useCommits.tests.ts
+++ b/tests/flow/useCommits.tests.ts
@@ -1,0 +1,87 @@
+import { assertEquals } from '../tests.deps.ts';
+import { h, render } from 'npm:preact@10.20.1';
+import { act } from 'npm:preact@10.20.1/test-utils';
+import { FakeTime } from 'jsr:@std/testing@0.210.0/time';
+import { EaCStatusProcessingTypes, type EaCStatus } from '../../src/flow/.deps.ts';
+import { WorkspaceManager } from '../../src/flow/managers/WorkspaceManager.tsx';
+
+Deno.test('UseCommits sets badge state based on commit statuses', async () => {
+  const scenarios: Array<{ statuses: EaCStatusProcessingTypes[]; expected: string }> = [
+    { statuses: [EaCStatusProcessingTypes.COMPLETE], expected: 'success' },
+    { statuses: [EaCStatusProcessingTypes.ERROR], expected: 'error' },
+    { statuses: [EaCStatusProcessingTypes.PROCESSING], expected: 'processing' },
+  ];
+
+  for (const { statuses, expected } of scenarios) {
+    const wm = {
+      ListCommits: async () => statuses.map((_, i) => ({ ID: `${i}` })),
+      GetCommitStatus: async (id: string) => ({
+        ID: id,
+        Processing: statuses[Number(id)],
+      }) as EaCStatus,
+    } as unknown as WorkspaceManager;
+
+    let hook: ReturnType<WorkspaceManager['UseCommits']>;
+    function Test() {
+      hook = WorkspaceManager.prototype.UseCommits.call(wm);
+      return null;
+    }
+
+    const container = document.createElement('div');
+    await act(() => {
+      render(h(Test, {}), container);
+    });
+
+    // Allow async load to resolve
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    assertEquals(hook.badgeState, expected);
+    render(null, container);
+  }
+});
+
+Deno.test('UseCommits polls and clears interval on unmount', async () => {
+  const time = new FakeTime();
+
+  let calls = 0;
+  const wm = {
+    ListCommits: async () => {
+      calls++;
+      return [] as EaCStatus[];
+    },
+    GetCommitStatus: async () => ({}) as EaCStatus,
+  } as unknown as WorkspaceManager;
+
+  let hook: ReturnType<WorkspaceManager['UseCommits']>;
+  function Test() {
+    hook = WorkspaceManager.prototype.UseCommits.call(wm);
+    return null;
+  }
+
+  const container = document.createElement('div');
+  await act(() => {
+    render(h(Test, {}), container);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  assertEquals(calls, 1);
+
+  await act(() => {
+    time.tick(4000);
+  });
+  assertEquals(calls, 2);
+
+  await act(() => {
+    render(null, container);
+  });
+  await act(() => {
+    time.tick(4000);
+  });
+  assertEquals(calls, 2);
+
+  time.restore();
+});

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -1,1 +1,2 @@
 import './utils/.tests.ts';
+import './flow/.tests.ts';


### PR DESCRIPTION
## Summary
- document commit indicator and flyout behavior in README
- add unit tests for UseCommits hook badge states and polling cleanup
- add CommitStatusPanel rendering test

## Testing
- `deno fmt --check` *(fails: command not found)*
- `deno lint` *(fails: command not found)*
- `deno test -A tests/tests.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b5ce0df4c83269daf42cce3806e97