### PR TITLE
feat: expose API descriptors hook

### DIFF
--- a/src/flow/managers/eac/EaCNodeCapabilityManager.ts
+++ b/src/flow/managers/eac/EaCNodeCapabilityManager.ts
@@ -4,6 +4,7 @@ import { OpenIndustrialAPIClient } from '../../../api/clients/OpenIndustrialAPIC
 import { EaCFlowNodeMetadata } from '../../../eac/EaCFlowNodeMetadata.ts';
 import { EverythingAsCodeOIWorkspace } from '../../../eac/EverythingAsCodeOIWorkspace.ts';
 import { Position } from '../../../eac/types/Position.ts';
+import { APIEndpointDescriptor } from '../../../types/APIEndpointDescriptor.ts';
 import { ComponentType, EaCVertexDetails, NullableArrayOrObject } from '../../.deps.ts';
 import { FlowGraphEdge } from '../../types/graph/FlowGraphEdge.ts';
 import { FlowGraphNode } from '../../types/graph/FlowGraphNode.ts';
@@ -149,6 +150,17 @@ export abstract class EaCNodeCapabilityManager<
   }
 
   /**
+   * Returns the API endpoint descriptors for this node type, if any.
+   * Subclasses should override `getAPIDescriptors` to provide descriptors.
+   */
+  public GetAPIDescriptors(
+    node: FlowGraphNode,
+    context: EaCNodeCapabilityContext,
+  ): APIEndpointDescriptor[] {
+    return this.getAPIDescriptors?.(node, context) ?? [];
+  }
+
+  /**
    * Returns the event router for this capability’s node type, if any.
    * Subclasses should override `getEventRouter` to provide scoped behavior.
    */
@@ -271,6 +283,14 @@ export abstract class EaCNodeCapabilityManager<
   ): Promise<Record<string, unknown>> {
     return await this.oiSvc.Stats.GetStats(type, id);
   }
+
+  /**
+   * Optional override to return API endpoint descriptors for this node type.
+   */
+  protected getAPIDescriptors?(
+    node: FlowGraphNode,
+    context: EaCNodeCapabilityContext,
+  ): APIEndpointDescriptor[];
 
   /**
    * Optional override to return the NodeEventRouter for this node type.


### PR DESCRIPTION
## Summary
- expose ApiEndpointDescriptor imports and public GetAPIDescriptors method for node capabilities
- add optional protected hook for subclasses to supply endpoint descriptors
- use APIEndpointDescriptor without alias

## Testing
- `deno fmt src/flow/managers/eac/EaCNodeCapabilityManager.ts` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: requested URL returned 403)*
- `deno task test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b5e3574188326a6643945151fb1f3