### PR TITLE
feat: add surface connection API descriptors

### DIFF
--- a/src/packs/oi-core/capabilities/surface-connection/SurfaceConnectionNodeCapabilityManager.ts
+++ b/src/packs/oi-core/capabilities/surface-connection/SurfaceConnectionNodeCapabilityManager.ts
@@ -9,6 +9,8 @@ import {
   FlowGraphNode,
 } from '../../../../flow/.exports.ts';
 import { ComponentType, FunctionComponent, memo, NullableArrayOrObject } from '../../.deps.ts';
+import { APIEndpointDescriptor } from '../../../../types/APIEndpointDescriptor.ts';
+import { DataConnectionNodeCapabilityManager } from '../connection/DataConnectionNodeCapabilityManager.ts';
 import { SurfaceConnectionInspector } from './SurfaceConnectionInspector.tsx';
 import SurfaceConnectionNodeRenderer from './SurfaceConnectionNodeRenderer.tsx';
 
@@ -196,6 +198,27 @@ export class SurfaceConnectionNodeCapabilityManager
       },
     };
   }
+
+  protected override getAPIDescriptors(
+    node: FlowGraphNode,
+    ctx: EaCNodeCapabilityContext,
+    ): APIEndpointDescriptor[] {
+    const [surfaceId, connId] = this.extractCompoundIDs(node);
+
+    const dcDescriptors = (
+      new DataConnectionNodeCapabilityManager() as unknown as {
+        getAPIDescriptors(
+          node: FlowGraphNode,
+          ctx: EaCNodeCapabilityContext,
+          ): APIEndpointDescriptor[];
+      }
+      ).getAPIDescriptors({ ...node, ID: connId }, ctx);
+
+      return dcDescriptors.map((desc) => ({
+        ...desc,
+        Path: `/api/surface/${surfaceId}${desc.Path.replace(/^\/api/, '')}`,
+      }));
+    }
 
   protected override getInspector() {
     return SurfaceConnectionInspector;


### PR DESCRIPTION
## Summary
- import ApiEndpointDescriptor and DataConnection manager for surface connection capability
- generate surface-scoped API descriptors by reusing data connection endpoints
- remove aliasing of APIEndpointDescriptor

## Testing
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: The requested URL returned error: 403)*
- `deno lint src/packs/oi-core/capabilities/surface-connection/SurfaceConnectionNodeCapabilityManager.ts` *(fails: command not found: deno)*
- `deno test` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_b_689b6819c60083268775e70ab443cca0