### PR TITLE
feat: add warm query api descriptors

### DIFF
--- a/src/packs/oi-core/capabilities/surface-warmquery/SurfaceWarmQueryNodeCapabilityManager.tsx
+++ b/src/packs/oi-core/capabilities/surface-warmquery/SurfaceWarmQueryNodeCapabilityManager.tsx
@@ -15,6 +15,7 @@ import { ComponentType, FunctionComponent, memo, NullableArrayOrObject } from '.
 import SurfaceWarmQueryNodeRenderer from './SurfaceWarmQueryNodeRenderer.tsx';
 import { SurfaceWarmQueryStats } from './SurfaceWarmQueryStats.tsx';
 import { EverythingAsCodeOIWorkspace } from '../../../../eac/EverythingAsCodeOIWorkspace.ts';
+import { APIEndpointDescriptor } from '../../../../types/APIEndpointDescriptor.ts';
 
 // ✅ Compound node detail type
 type SurfaceWarmQueryNodeDetails = EaCWarmQueryDetails & SurfaceWarmQuerySettings;
@@ -348,6 +349,23 @@ export class SurfaceWarmQueryNodeCapabilityManager
 
   protected override getPreset() {
     return { Type: this.Type, Label: 'Warm Query', IconKey: 'warmQuery' };
+  }
+
+  protected override getAPIDescriptors(
+    node: FlowGraphNode,
+    context: EaCNodeCapabilityContext,
+  ): APIEndpointDescriptor[] {
+    const apiPath = context.GetEaC().WarmQueries?.[node.ID]?.Details?.ApiPath;
+
+    if (!apiPath) return [];
+
+    const cleanedPath = apiPath.replace(/^\/+/, '');
+    const base = `/api/warm/${cleanedPath}`;
+
+    return [
+      { Method: 'GET', Path: base, Warm: true } as APIEndpointDescriptor,
+      { Method: 'POST', Path: base, Warm: true } as APIEndpointDescriptor,
+    ];
   }
 
   protected override getRenderer() {


### PR DESCRIPTION
## Summary
- import `APIEndpointDescriptor` in warm query capability manager
- describe GET/POST `/api/warm/{apiPath}` endpoints for warm queries

## Testing
- `deno task test` *(fails: command not found)*
- `curl -fsSL https://deno.land/x/install/install.sh | sh` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_b_689b68212d288326990cdb072f0d571e