### PR TITLE
feat: navigate to commit details on double-click

### DIFF
--- a/atomic/organisms/CommitStatusPanel.tsx
+++ b/atomic/organisms/CommitStatusPanel.tsx
@@ -125,6 +125,10 @@ export function CommitStatusPanel({
                   isSelected ? 'bg-neutral-800' : '',
                 ])}
                 onClick={() => onSelectCommit(commit.ID)}
+                onDblClick={() => {
+                  onSelectCommit(commit.ID);
+                  location.href = `/workspace/commit/${commit.ID}`;
+                }}
               >
                 <CommitIcon
                   class={classSet(['w-4 h-4', statusColor(commit.Processing)])}


### PR DESCRIPTION
## Summary
- allow selecting commits via prop `selectedCommitId`
- highlight selected commit entries
- open commit details on double-click

## Testing
- `deno task test` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_b_689b69a3476883269f4a937f73891823