### PR TITLE
feat(api): add API catalog builder

### DIFF
--- a/src/api/.exports.ts
+++ b/src/api/.exports.ts
@@ -1,2 +1,3 @@
 export * from './clients/.exports.ts';
 export * from './impulses/.exports.ts';
+export * from './APICatalog.ts';

--- a/src/api/APICatalog.ts
+++ b/src/api/APICatalog.ts
@@ -1,0 +1,30 @@
+import { APIEndpointDescriptor } from '../types/APIEndpointDescriptor.ts';
+import { EaCNodeCapabilityManager } from '../flow/managers/eac/EaCNodeCapabilityManager.ts';
+import { FlowGraphNode } from '../flow/types/graph/FlowGraphNode.ts';
+import { EaCNodeCapabilityContext } from '../flow/types/nodes/EaCNodeCapabilityContext.ts';
+
+/**
+ * Build a catalog of API endpoint descriptors for the given nodes.
+ *
+ * Each node is checked against the provided capability managers. When a
+ * matching manager is found, its `GetAPIDescriptors` implementation is used
+ * to gather endpoint metadata. The combined list of descriptors is returned.
+ */
+export function APICatalog(
+  nodes: FlowGraphNode[],
+  capabilityManagers: EaCNodeCapabilityManager[],
+  context: EaCNodeCapabilityContext,
+): APIEndpointDescriptor[] {
+  const descriptors: APIEndpointDescriptor[] = [];
+
+  for (const node of nodes) {
+    for (const manager of capabilityManagers) {
+      if (manager.Matches(node)) {
+        descriptors.push(...manager.GetAPIDescriptors(node, context));
+        break;
+      }
+    }
+  }
+
+  return descriptors;
+}


### PR DESCRIPTION
## Summary
- add APICatalog builder to aggregate API descriptors across node capabilities
- re-export APICatalog from api exports

## Testing
- `deno test -A tests/tests.ts` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_b_689b6a7988208326ab9e7d41bf198fd6