### PR TITLE
docs: document capability manager API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # open-industrial-reference-architecture
+
+## Capability Managers and API Endpoints
+
+API endpoints for each node capability are defined by its capability manager. Implementations expose their HTTP interfaces by overriding the `getAPIDescriptors` hook, which is surfaced through the public `GetAPIDescriptors` method. Each returned [`APIEndpointDescriptor`](src/types/APIEndpointDescriptor.ts) describes an endpoint the runtime should register.
+
+```ts
+protected override getAPIDescriptors(
+  node: FlowGraphNode,
+  ctx: EaCNodeCapabilityContext,
+): APIEndpointDescriptor[] {
+  return [{
+    Method: 'GET',
+    Path: `/api/my-nodes/${node.ID}`,
+    Description: 'Fetch data for the node',
+  }];
+}
+```
+
+## Custom Capability Manager Example
+
+Custom node types can extend `EaCNodeCapabilityManager` to participate in the flow graph and expose APIs. Alongside `getAPIDescriptors`, other lifecycle methods may be overridden to tailor behaviour.
+
+```ts
+import {
+  APIEndpointDescriptor,
+  EaCNodeCapabilityContext,
+  EaCNodeCapabilityManager,
+  FlowGraphNode,
+} from './src/flow/.exports.ts';
+
+export class CounterNodeCapabilityManager
+  extends EaCNodeCapabilityManager<CounterDetails> {
+  public Type = 'counter';
+
+  protected override buildNode(
+    id: string,
+    _ctx: EaCNodeCapabilityContext,
+  ): FlowGraphNode {
+    return { ID: id, Type: this.Type };
+  }
+
+  protected override getAPIDescriptors(
+    node: FlowGraphNode,
+    ctx: EaCNodeCapabilityContext,
+  ): APIEndpointDescriptor[] {
+    return [{
+      Method: 'POST',
+      Path: `/counter/${node.ID}/increment`,
+      Description: 'Increment the counter value',
+    }];
+  }
+}
+```
+


### PR DESCRIPTION
## Summary
- explain how capability managers define API endpoints via `getAPIDescriptors`
- show an example capability manager for a custom node type

## Testing
- `deno fmt README.md` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403)*
- `npm install -g deno` *(fails: 403)*
- `deno task test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b6ceea3408326b90a60f72787fe16