### PR TITLE
feat: refresh EaC with timer

### DIFF
--- a/src/runtimes/processors/EaCOIImpulseStreamProcessorHandlerResolver.ts
+++ b/src/runtimes/processors/EaCOIImpulseStreamProcessorHandlerResolver.ts
@@ -218,6 +218,19 @@ async function createImpulseRuntime({
     eac = await oiSvc.Workspaces.Get();
   };
 
+  let refreshTimer: number | undefined;
+
+  const scheduleEaCRefresh = () => {
+    if (refreshTimer) {
+      return;
+    }
+
+    refreshTimer = setTimeout(async () => {
+      refreshTimer = undefined;
+      await loadEaC();
+    }, 5000);
+  };
+
   await loadEaC();
 
   let stop: () => void;
@@ -245,7 +258,7 @@ async function createImpulseRuntime({
 
           listeners.forEach((cb) => cb(impulse));
 
-          loadEaC();
+          scheduleEaCRefresh();
         } catch (err) {
           logger.warn('[ImpulseStream] ⚠️ Failed to parse impulse', err);
         }


### PR DESCRIPTION
## Summary
- load EaC once at startup
- refresh EaC on a throttled timer after impulses

## Testing
- `deno task test` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_b_68b2f930c2c0832681f402b25bb4fd0c