### PR TITLE
feat: create per-socket ephemeral consumers

### DIFF
--- a/src/utils/createEphemeralConsumer.ts
+++ b/src/utils/createEphemeralConsumer.ts
@@ -12,7 +12,7 @@ export async function createEphemeralConsumer(
     headers?: Headers;
   }) => void,
   consumerConfig?: Partial<ConsumerConfig>,
-): Promise<{ stop: () => void }> {
+): Promise<{ stop: () => void; delete: () => Promise<void> }> {
   stream = sanitizeStreamName(stream);
 
   try {
@@ -54,5 +54,6 @@ export async function createEphemeralConsumer(
 
   return {
     stop: () => abort.abort(),
+    delete: () => jsm.consumers.delete(stream, consumerName),
   };
 }


### PR DESCRIPTION
## Summary
- spawn a dedicated ephemeral NATS consumer for each WebSocket connection
- start consumer from connection time and clean it up when socket closes
- expose consumer deletion helper in `createEphemeralConsumer`

## Testing
- `deno fmt src/utils/createEphemeralConsumer.ts src/runtimes/processors/EaCOIImpulseStreamProcessorHandlerResolver.ts` *(fail: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fail: 403 error)*
- `apt-get update` *(fail: repository 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b5416ae1d88326a9979191f41d3b96