### PR TITLE
feat: add admin commit delete

### DIFF
--- a/src/api/clients/OpenIndustrialAdminAPI.ts
+++ b/src/api/clients/OpenIndustrialAdminAPI.ts
@@ -1,6 +1,8 @@
 // src/api/clients/OpenIndustrialAdminAPI.ts
+import { EverythingAsCode } from 'jsr:@fathym/eac@0.2.119';
 import { EverythingAsCodeOIWorkspace } from '../../eac/EverythingAsCodeOIWorkspace.ts';
 import { ClientHelperBridge } from './ClientHelperBridge.ts';
+import { EaCStatus } from '../.client.deps.ts';
 
 /**
  * Administrative API subclient for OpenIndustrial.  Provides methods
@@ -28,6 +30,50 @@ export class OpenIndustrialAdminAPI {
     if (!res.ok) {
       throw new Error(`Failed to list enterprises: ${res.status}`);
     }
+    return await this.bridge.json(res);
+  }
+
+  /**
+   * Commit (create or update) a top-level EaC definition.
+   *
+   * @param eac - The Everything-as-Code payload to commit.
+   * @returns The commit status and commit ID from the steward.
+   */
+  public async CommitEaC(
+    eac: EverythingAsCode,
+  ): Promise<{ status: EaCStatus; commitId: string }> {
+    const res = await fetch(this.bridge.url('/api/admin/commit'), {
+      method: 'POST',
+      headers: this.bridge.headers(),
+      body: JSON.stringify(eac),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to commit EaC: ${res.status}`);
+    }
+
+    return await this.bridge.json(res);
+  }
+
+  /**
+   * Delete (archive) a top-level EaC definition.
+   *
+   * @param eac - A minimal EaC object identifying what to delete.
+   * @returns The status of the delete operation.
+   */
+  public async DeleteEaC(
+    eac: Partial<EverythingAsCode>,
+  ): Promise<{ status: EaCStatus }> {
+    const res = await fetch(this.bridge.url('/api/admin/commit'), {
+      method: 'DELETE',
+      headers: this.bridge.headers(),
+      body: JSON.stringify(eac),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to delete EaC: ${res.status}`);
+    }
+
     return await this.bridge.json(res);
   }
 }


### PR DESCRIPTION
## Summary
- add commit and delete support to OpenIndustrialAdminAPI

## Testing
- `deno fmt src/api/clients/OpenIndustrialAdminAPI.ts` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh -s v1.46.3` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b7bc732af88326bba3a537a51a0af8